### PR TITLE
Install Supervisor correctly and use exact Centos 7 Version

### DIFF
--- a/os/centos/base/Dockerfile
+++ b/os/centos/base/Dockerfile
@@ -1,19 +1,20 @@
-FROM centos:latest
+FROM centos:7.3.1611
 MAINTAINER "Sophia Hudson" <sophia.hudson@technicallyspeaking.io>
 LABEL version="0.1.0"
 
 RUN yum group install -y "Development Tools" && \
     yum -y install epel-release \
-		   supervisor \
-                   libevent-devel \
-                   ncurses-devel \
-                   glib-c-static \
-                   vim \
-                   wget \
-                   telnet \
-                   dig \
-                   p7zip \
+		   python-setuptools \
+           libevent-devel \
+           ncurses-devel \
+           glib-c-static \
+           vim \
+           wget \
+           telnet \
+           dig \
+           p7zip \
 		   git && \
+    easy_install supervisor && \
     mkdir -p /root/.vim/bundle && \
     git clone https://github.com/VundleVim/Vundle.vim.git /root/.vim/bundle/vundle && \
     git clone https://github.com/flazz/vim-colorschemes.git /root/.vim/bundle/vim-colorschemes && \

--- a/os/centos/base/build.sh
+++ b/os/centos/base/build.sh
@@ -3,6 +3,4 @@ source .buildvars
 echo $GIT_BRANCH
 docker build \
   --build-arg $GIT_BRANCH \
-#  --squash \
-#  --compress \
   -t $DOCKER_REPOSITORY:$DOCKER_IMAGE_TAG .


### PR DESCRIPTION
Increases the reliability of the container by specifying an exact CentOS version.
Fixes supervisor installation.